### PR TITLE
add c#/dotnet runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ as default. But you can register your own command and apply other languages.
 
 * C(gcc or clang or Visual C++)
 * C++(g++ or clang++ or Visual C++)
+* C#(dotnet or mono)
 * Objective-C(gcc -objc)
 * D Language(dmd)
 * Fortran(gfortran)

--- a/quickrun.el
+++ b/quickrun.el
@@ -146,6 +146,7 @@
 (quickrun--defvar quickrun-option-default-directory
                   nil file-directory-p
                   "Default directory where command is executed")
+
 ;; hooks
 (defvar quickrun-after-run-hook nil
   "Run hook after execute quickrun")

--- a/quickrun.el
+++ b/quickrun.el
@@ -107,24 +107,24 @@
         `(put (quote ,name) 'safe-local-variable (quote ,safep)))))
 
 (quickrun--defvar quickrun-option-cmd-alist
-  nil listp
-  "Specify command alist directly as file local variable")
+                  nil listp
+                  "Specify command alist directly as file local variable")
 
 (quickrun--defvar quickrun-option-command
-  nil stringp
-  "Specify command directly as file local variable")
+                  nil stringp
+                  "Specify command directly as file local variable")
 
 (quickrun--defvar quickrun-option-cmdkey
-  nil stringp
-  "Specify language key directly as file local variable")
+                  nil stringp
+                  "Specify language key directly as file local variable")
 
 (quickrun--defvar quickrun-option-cmdopt
-  nil stringp
-  "Specify command option directly as file local variable")
+                  nil stringp
+                  "Specify command option directly as file local variable")
 
 (quickrun--defvar quickrun-option-args
-  nil stringp
-  "Specify command argument directly as file local variable")
+                  nil stringp
+                  "Specify command argument directly as file local variable")
 
 (defun quickrun--outputter-p (_x)
   (lambda (x)
@@ -132,21 +132,20 @@
         (quickrun--outputter-multi-p x))))
 
 (quickrun--defvar quickrun-option-outputter
-  nil quickrun--outputter-p
-  "Specify format function output buffer as file local variable")
+                  nil quickrun--outputter-p
+                  "Specify format function output buffer as file local variable")
 
 (quickrun--defvar quickrun-option-shebang
-  t booleanp
-  "Select using command from schebang as file local variable")
+                  t booleanp
+                  "Select using command from schebang as file local variable")
 
 (quickrun--defvar quickrun-option-timeout-seconds
-  nil integerp
-  "Timeout seconds as file local variable")
+                  nil integerp
+                  "Timeout seconds as file local variable")
 
 (quickrun--defvar quickrun-option-default-directory
-  nil file-directory-p
-  "Default directory where command is executed")
-
+                  nil file-directory-p
+                  "Default directory where command is executed")
 ;; hooks
 (defvar quickrun-after-run-hook nil
   "Run hook after execute quickrun")

--- a/quickrun.el
+++ b/quickrun.el
@@ -107,24 +107,24 @@
         `(put (quote ,name) 'safe-local-variable (quote ,safep)))))
 
 (quickrun--defvar quickrun-option-cmd-alist
-                  nil listp
-                  "Specify command alist directly as file local variable")
+  nil listp
+  "Specify command alist directly as file local variable")
 
 (quickrun--defvar quickrun-option-command
-                  nil stringp
-                  "Specify command directly as file local variable")
+  nil stringp
+  "Specify command directly as file local variable")
 
 (quickrun--defvar quickrun-option-cmdkey
-                  nil stringp
-                  "Specify language key directly as file local variable")
+  nil stringp
+  "Specify language key directly as file local variable")
 
 (quickrun--defvar quickrun-option-cmdopt
-                  nil stringp
-                  "Specify command option directly as file local variable")
+  nil stringp
+  "Specify command option directly as file local variable")
 
 (quickrun--defvar quickrun-option-args
-                  nil stringp
-                  "Specify command argument directly as file local variable")
+  nil stringp
+  "Specify command argument directly as file local variable")
 
 (defun quickrun--outputter-p (_x)
   (lambda (x)
@@ -132,20 +132,20 @@
         (quickrun--outputter-multi-p x))))
 
 (quickrun--defvar quickrun-option-outputter
-                  nil quickrun--outputter-p
-                  "Specify format function output buffer as file local variable")
+  nil quickrun--outputter-p
+  "Specify format function output buffer as file local variable")
 
 (quickrun--defvar quickrun-option-shebang
-                  t booleanp
-                  "Select using command from schebang as file local variable")
+  t booleanp
+  "Select using command from schebang as file local variable")
 
 (quickrun--defvar quickrun-option-timeout-seconds
-                  nil integerp
-                  "Timeout seconds as file local variable")
+  nil integerp
+  "Timeout seconds as file local variable")
 
 (quickrun--defvar quickrun-option-default-directory
-                  nil file-directory-p
-                  "Default directory where command is executed")
+  nil file-directory-p
+  "Default directory where command is executed")
 
 ;; hooks
 (defvar quickrun-after-run-hook nil
@@ -218,6 +218,11 @@
                             "%e %a"))
                (:remove  . ("%e"))
                (:description . "Compile Objective-C file with gcc and execute")))
+
+    ("c#/dotnet" . ((:command . "dotnet run")
+                    (:remove  . ("bin" "obj"))
+                    (:compile-only . "dotnet build")
+                    (:description . "Run .NET project")))
 
     ("c#/mono" . ((:command . "mono")
                   (:exec    . ("mcs %o %s" "%c %n.exe %a"))
@@ -1129,7 +1134,7 @@ by quickrun.el. But you can register your own command for some languages")
 (defconst quicklang/lang-candidates
   `(("c" . ,(quickrun--c-compiler))
     ("c++" . ,(quickrun--c++-compiler))
-    ("c#" . ("mono"))
+    ("c#" . ("dotnet" "mono"))
     ("fortran" . ("gfortran"))
     ("javascript" . ("node" "v8" "js" "jrunscript" "cscript"))
     ("ruby" . ("ruby" "mruby"))


### PR DESCRIPTION
Hi, 

There is no .Net Core support and as it's now a cross-platform I am adding c#/dotnet merge. 

This merge: 
- Add both mono and dotnet to README,
- Add command, 
- Add compile-only 
and, specify which folders should be removed. 

Thanks!


